### PR TITLE
Update sync_garmin_to_notion.yml

### DIFF
--- a/.github/workflows/sync_garmin_to_notion.yml
+++ b/.github/workflows/sync_garmin_to_notion.yml
@@ -4,7 +4,7 @@ on:
   schedule:
     # - cron: '0 1 * * *' # Daily at 1 am
     # - cron: '0 */6 * * *' # Every 6 hours
-    - cron: '0 0,6,8,12,18,22 * * *'
+    - cron: '0 0,4,6,12,14,18 * * *'
   workflow_dispatch:
 env:
   TZ: 'America/Chicago'


### PR DESCRIPTION
didn't realize that GH Actions only use UTC for crons